### PR TITLE
Remove `sarif` upload from Anchore Scan

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -23,7 +23,3 @@ jobs:
         image: "localbuild/testimage:latest"
         acs-report-enable: true
         severity-cutoff: critical
-    - name: Upload Anchore Scan Report
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: results.sarif


### PR DESCRIPTION
Removes 
```YAML
    - name: Upload Anchore Scan Report
      uses: github/codeql-action/upload-sarif@v1
      with:
        sarif_file: results.sarif
```

to prevent "resource not accessible" error.